### PR TITLE
Apply opacity to Image widget

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -68,11 +68,12 @@ class AppWrapper extends HookWidget {
         children: [
           ImageFiltered(
             imageFilter: ImageFilter.blur(sigmaX: 60, sigmaY: 60),
-            child: Image.asset("assets/images/background-small.jpg",
-                fit: BoxFit.cover),
-          ),
-          Container(
-            color: const Color.fromARGB(77, 0, 0, 0),
+            child: Image.asset(
+              "assets/images/background-small.jpg",
+              fit: BoxFit.cover,
+              color: const Color.fromARGB(77, 0, 0, 0),
+              colorBlendMode: BlendMode.luminosity,
+            ),
           ),
           const PianoRollController(child: PianoRoll()),
         ],


### PR DESCRIPTION
This PR uses the `color` property of the Image constructor to apply opacity directly to the image, rather than by rendering a partially transparent container above it.