### PR TITLE
Sort imports and always use relative imports

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,29 +1,10 @@
-# This file configures the analyzer, which statically analyzes Dart code to
-# check for errors, warnings, and lints.
-#
-# The issues identified by the analyzer are surfaced in the UI of Dart-enabled
-# IDEs (https://dart.dev/tools#ides-and-editors). The analyzer can also be
-# invoked from the command line by running `flutter analyze`.
-
-# The following line activates a set of recommended lints for Flutter apps,
-# packages, and plugins designed to encourage good coding practices.
 include: package:flutter_lints/flutter.yaml
 
-linter:
-  # The lint rules applied to this project can be customized in the
-  # section below to disable rules from the `package:flutter_lints/flutter.yaml`
-  # included above or to enable additional rules. A list of all available lints
-  # and their documentation is published at
-  # https://dart-lang.github.io/linter/lints/index.html.
-  #
-  # Instead of disabling a lint rule for the entire project in the
-  # section below, it can also be suppressed for a single line of code
-  # or a specific dart file by using the `// ignore: name_of_lint` and
-  # `// ignore_for_file: name_of_lint` syntax on the line or in the file
-  # producing the lint.
-  rules:
-    # avoid_print: false  # Uncomment to disable the `avoid_print` rule
-    # prefer_single_quotes: true  # Uncomment to enable the `prefer_single_quotes` rule
+analyzer:
+  strong-mode:
+    implicit-casts: false
+    implicit-dynamic: false
 
-# Additional information about this file can be found at
-# https://dart.dev/guides/language/analysis-options
+linter:
+  rules:
+    prefer_relative_imports: true

--- a/lib/helpers.dart
+++ b/lib/helpers.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/foundation.dart';
-import 'package:flutter_piano_roll/pattern.dart';
+
+import 'pattern.dart';
 
 enum KeyType { black, white }
 enum NotchType { above, below, both }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,13 +1,15 @@
 import 'dart:ui';
+
 import 'package:flutter/widgets.dart';
+
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_piano_roll/helpers.dart';
-import 'package:flutter_piano_roll/piano_roll.dart';
-import 'package:flutter_piano_roll/piano_roll_controller.dart';
 import 'package:provider/provider.dart';
-import 'package:flutter_piano_roll/pattern.dart';
 
 import 'globals.dart';
+import 'helpers.dart';
+import 'pattern.dart';
+import 'piano_roll.dart';
+import 'piano_roll_controller.dart';
 
 void main() {
   runApp(

--- a/lib/pattern.dart
+++ b/lib/pattern.dart
@@ -1,5 +1,5 @@
-import 'package:flutter/widgets.dart';
 import 'package:flutter/foundation.dart';
+import 'package:flutter/widgets.dart';
 
 import 'globals.dart';
 

--- a/lib/piano_control.dart
+++ b/lib/piano_control.dart
@@ -1,8 +1,9 @@
 import 'package:flutter/widgets.dart';
+
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_piano_roll/helpers.dart';
 
 import 'globals.dart';
+import 'helpers.dart';
 
 class DragInfo {
   double startX;

--- a/lib/piano_roll.dart
+++ b/lib/piano_roll.dart
@@ -1,12 +1,14 @@
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
+
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_piano_roll/helpers.dart';
-import 'package:flutter_piano_roll/piano_roll_notifications.dart';
-import 'package:flutter_piano_roll/pattern.dart';
-import 'package:flutter_piano_roll/piano_roll_grid.dart';
-import 'package:flutter_piano_roll/timeline.dart';
 import 'package:provider/provider.dart';
+
+import 'helpers.dart';
+import 'pattern.dart';
+import 'piano_roll_grid.dart';
+import 'piano_roll_notifications.dart';
+import 'timeline.dart';
 
 import './piano_control.dart';
 

--- a/lib/piano_roll_controller.dart
+++ b/lib/piano_roll_controller.dart
@@ -1,8 +1,10 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_piano_roll/globals.dart';
-import 'package:flutter_piano_roll/piano_roll_notifications.dart';
-import 'package:flutter_piano_roll/pattern.dart';
+
 import 'package:provider/provider.dart';
+
+import 'globals.dart';
+import 'pattern.dart';
+import 'piano_roll_notifications.dart';
 
 import 'helpers.dart';
 

--- a/lib/piano_roll_grid.dart
+++ b/lib/piano_roll_grid.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/widgets.dart';
-import 'package:flutter_piano_roll/helpers.dart';
+
 import 'package:provider/provider.dart';
-import 'package:flutter_piano_roll/pattern.dart';
+
+import 'helpers.dart';
+import 'pattern.dart';
 
 class PianoRollGrid extends StatelessWidget {
   const PianoRollGrid({

--- a/lib/timeline.dart
+++ b/lib/timeline.dart
@@ -1,12 +1,13 @@
 import 'dart:math';
 
 import 'package:flutter/widgets.dart';
+
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_piano_roll/pattern.dart';
 import 'package:provider/provider.dart';
 
 import 'globals.dart';
 import 'helpers.dart';
+import 'pattern.dart';
 
 final _timelineKey = GlobalKey();
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,20 +1,8 @@
 name: flutter_piano_roll
 description: A new Flutter project.
 
-# The following line prevents the package from being accidentally published to
-# pub.dev using `pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: 'none'
 
-# The following defines the version and build number for your application.
-# A version number is three numbers separated by dots, like 1.2.43
-# followed by an optional build number separated by a +.
-# Both the version and the builder number may be overridden in flutter
-# build by specifying --build-name and --build-number, respectively.
-# In Android, build-name is used as versionName while build-number used as versionCode.
-# Read more about Android versioning at https://developer.android.com/studio/publish/versioning
-# In iOS, build-name is used as CFBundleShortVersionString while build-number used as CFBundleVersion.
-# Read more about iOS versioning at
-# https://developer.apple.com/library/archive/documentation/General/Reference/InfoPlistKeyReference/Articles/CoreFoundationKeys.html
 version: 1.0.0+1
 
 environment:
@@ -24,55 +12,14 @@ dependencies:
   flutter:
     sdk: flutter
 
-
-  # The following adds the Cupertino Icons font to your application.
-  # Use with the CupertinoIcons class for iOS style icons.
-  # cupertino_icons: ^1.0.2
   flutter_hooks: ^0.18.0
-  provider: ^5.0.0
+  provider: ^6.0.1
 
 dev_dependencies:
   flutter_lints: ^1.0.4
   flutter_test:
     sdk: flutter
 
-# For information on the generic Dart part of this file, see the
-# following page: https://dart.dev/tools/pub/pubspec
-
-# The following section is specific to Flutter.
 flutter:
-
-  # The following line ensures that the Material Icons font is
-  # included with your application, so that you can use the icons in
-  # the material Icons class.
-  uses-material-design: true
-
-  # To add assets to your application, add an assets section, like this:
   assets:
     - assets/images/
-
-  # An image asset can refer to one or more resolution-specific "variants", see
-  # https://flutter.dev/assets-and-images/#resolution-aware.
-
-  # For details regarding adding assets from package dependencies, see
-  # https://flutter.dev/assets-and-images/#from-packages
-
-  # To add custom fonts to your application, add a fonts section here,
-  # in this "flutter" section. Each entry in this list should have a
-  # "family" key with the font family name, and a "fonts" key with a
-  # list giving the asset and other descriptors for the font. For
-  # example:
-  # fonts:
-  #   - family: Schyler
-  #     fonts:
-  #       - asset: fonts/Schyler-Regular.ttf
-  #       - asset: fonts/Schyler-Italic.ttf
-  #         style: italic
-  #   - family: Trajan Pro
-  #     fonts:
-  #       - asset: fonts/TrajanPro.ttf
-  #       - asset: fonts/TrajanPro_Bold.ttf
-  #         weight: 700
-  #
-  # For details regarding fonts from package dependencies,
-  # see https://flutter.dev/custom-fonts/#from-packages


### PR DESCRIPTION
This PR sorts all the imports into 4 groups:

1. Dart
2. Flutter
3. Packages
4. Relative

It also enables a lint rule to always import files in the same project with relative imports. This fixes an issue where Dart will treat your package as 2 different packages depending on how you import the files.