### PR TITLE
Upgrade provider to v6

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -115,7 +115,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.1"
   sky_engine:
     dependency: transitive
     description: flutter

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -29,7 +29,7 @@ dependencies:
   # Use with the CupertinoIcons class for iOS style icons.
   # cupertino_icons: ^1.0.2
   flutter_hooks: ^0.18.0
-  provider: ^5.0.0
+  provider: ^6.0.1
 
 dev_dependencies:
   flutter_lints: ^1.0.4


### PR DESCRIPTION
https://pub.dev/packages/provider/changelog

The breaking change doesn't affect us.