### PR TITLE
Do not allow note width to be < 0

### DIFF
--- a/lib/piano_roll.dart
+++ b/lib/piano_roll.dart
@@ -1,3 +1,5 @@
+import 'dart:math';
+
 import 'package:flutter/gestures.dart';
 import 'package:flutter/widgets.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
@@ -275,7 +277,7 @@ class NoteLayoutDelegate extends MultiChildLayoutDelegate {
 
       layoutChild(
         note.id,
-        BoxConstraints(maxHeight: height, maxWidth: width),
+        BoxConstraints(maxHeight: height, maxWidth: max(width, 0)),
       );
       positionChild(note.id, Offset(startX, y));
     }


### PR DESCRIPTION
Fixes #4.

This fixes an issue where the app can try to render a note with a `width` constraint less than 0.